### PR TITLE
Propagate tsds query errors back up the stack in the search dataservice

### DIFF
--- a/lib/GRNOC/TSDS/DataService/Search.pm
+++ b/lib/GRNOC/TSDS/DataService/Search.pm
@@ -426,7 +426,7 @@ sub search {
             order_by => $order_by,
             group_by => $group_by,
             having   => $having
-        );
+        ) || return;
 
         # loop through each of our data_results building arrays of names and values for each
         foreach my $result ( @$data_results ){
@@ -647,7 +647,7 @@ sub _get_search_result_data {
     # execute our query
     my $data_results = $self->parser()->evaluate($query, force_constraint => 1);
     if (!$data_results) {
-        $self->error( "Error parsing search data results: $!");
+        $self->error( "Error parsing search data results: ".$self->parser()->error());
         return;
     }
 


### PR DESCRIPTION
Errors happening at TSDS query time where being ignored which caused the search dataservice to return an empty array for its results. TSDS query errors will now be propagated up to the search dataservice and returned at the webservice layer. 