### PR TITLE
ISSUE=12427 fixed issue with eval_position on update of agg/exp

### DIFF
--- a/lib/GRNOC/TSDS/DataService/Aggregation.pm
+++ b/lib/GRNOC/TSDS/DataService/Aggregation.pm
@@ -157,11 +157,13 @@ sub update_aggregations {
     }
     
     # reorder eval positions
-    my $position_res = $self->_update_eval_positions(
-        collection => $agg_col, 
-        name => $name,
-        eval_position => $eval_position
-    );
+    if(defined($eval_position)){
+        my $position_res = $self->_update_eval_positions(
+            collection => $agg_col, 
+            name => $name,
+            eval_position => $eval_position
+        );
+    }
     
     my $set = {};
     my $id;
@@ -222,11 +224,13 @@ sub update_expirations {
     }
     
     # reorder eval positions
-    my $position_res = $self->_update_eval_positions(
-        collection => $exp_col,
-        name => $name,
-        eval_position => $eval_position
-    );
+    if(defined($eval_position)){
+        my $position_res = $self->_update_eval_positions(
+            collection => $exp_col,
+            name => $name,
+            eval_position => $eval_position
+        );
+    }
 
     
     # figure out which fields were modifying for the expire record


### PR DESCRIPTION
Updating an aggregation or expiration record and not sending the eval_position was causing it to always be set to 10.