### PR TITLE
ISSUE=12129 removing constraint on search query since it's possible t…

### DIFF
--- a/lib/GRNOC/TSDS/DataService/Search.pm
+++ b/lib/GRNOC/TSDS/DataService/Search.pm
@@ -721,7 +721,7 @@ sub _get_search_result_data {
 
 
     # execute our query
-    my $data_results = $self->parser()->evaluate($query, force_constraint => 1);
+    my $data_results = $self->parser()->evaluate($query, force_constraint => 0);
     if (!$data_results) {
         $self->error( "Error parsing search data results: ".$self->parser()->error());
         return;


### PR DESCRIPTION
…o have an order by value with no search term, which causes the inner query to have no limit set too and results in an unconstrained query error. The data doc limit is our safeguard here