### PR TITLE
Add dependency on DBD::MySQL to specfile

### DIFF
--- a/grnoc-tsds-services.spec
+++ b/grnoc-tsds-services.spec
@@ -62,6 +62,7 @@ Requires: perl-Sort-Versions
 Requires: perl-List-Flatten-Recursive
 Requires: perl-GRNOC-TSDS-Aggregate-Histogram
 Requires: perl-DBI
+Requires: perl-DBD-MySQL
 Requires: perl-GRNOC-Counter
 Requires: perl-Try-Tiny
 


### PR DESCRIPTION
When setting up TSDS on a host, I found that it required the Perl DBD::MySQL module, but it wasn't listed as a dependency by the RPM. This pull request has a fix for that.