### PR TITLE
Better limiting of RabbitMQ message size ISSUE=4929

### DIFF
--- a/bin/tsds_firehose.pl
+++ b/bin/tsds_firehose.pl
@@ -5,6 +5,7 @@ use warnings;
 
 use JSON::XS;
 use Net::AMQP::RabbitMQ;
+use Net::RabbitMQ::Management::API;
 
 use Getopt::Long;
 use Data::Dumper;
@@ -14,6 +15,8 @@ use Data::Dumper;
 use constant TYPE => 'interface';
 use constant INTERVAL => 30;
 use constant MESSAGE_SIZE => 1000;
+use constant QUEUE_CHECK_INTERVAL => 100;
+use constant RETRY_TIMEOUT => 10;
 
 ### command line options ###
 
@@ -23,19 +26,27 @@ my $interval = 30;
 my $num_measurements = 10;
 my $rabbit_host = '127.0.0.1';
 my $rabbit_port = 5672;
+my $rabbit_mgmt_port = 15672;
 my $rabbit_queue = 'timeseries_data';
 my $mode = 'sin-cos';
 my $start = 0;
 my $help;
+my $queue_size_limit = 0;
+my $check_aggregate_queue;
+my $aggregate_queue_size_limit = 0;
 
 GetOptions( 'num-updates=i' => \$num_updates,
             'num-measurements=i' => \$num_measurements,
             'rabbit-host=s' => \$rabbit_host,
             'rabbit-port=i' => \$rabbit_port,
+            'rabbit-mgmt-port=i' => \$rabbit_mgmt_port,
             'rabbit-queue=s' => \$rabbit_queue,
             'start=i' => \$start,
             'interval=i' => \$interval,
             'mode=s' => \$mode,
+            'queue-size-limit=i' => \$queue_size_limit, # 0 means no limit
+            'check-aggregate-queue=s' => \$check_aggregate_queue,
+            'aggregate-queue-size-limit=i' => \$aggregate_queue_size_limit, # 0 means no limit
             'help|h|?' => \$help );
 
 usage() if $help;
@@ -48,6 +59,7 @@ $rabbit->channel_open( 1 );
 my $timestamp = $start;
 my $counter = 0;
 my $messages = [];
+my $num_messages_sent = 0;
 
 while ( 1 ) {
 
@@ -62,7 +74,7 @@ while ( 1 ) {
     while ( scalar(@$messages) >= MESSAGE_SIZE ) {
 
         my @chunk = splice @$messages, 0, MESSAGE_SIZE;
-        $rabbit->publish( 1, $rabbit_queue, encode_json( \@chunk ), {'exchange' => ''} );
+        publish( \@chunk );
     }
 
     $counter++;
@@ -71,7 +83,8 @@ while ( 1 ) {
 
 # Push any remaining messages to RabbitMQ:
 if ( scalar(@$messages) > 0) {
-    $rabbit->publish( 1, $rabbit_queue, encode_json( $messages ), {'exchange' => ''} );
+
+    publish( $messages );
 }
 
 # all done
@@ -131,6 +144,80 @@ sub make_data {
     }
 
     return $data;
+}
+
+# Publish a message to RabbitMQ, with rate-limiting
+sub publish {
+
+    my $msg = shift;
+
+    check_queue_size() if $num_messages_sent % QUEUE_CHECK_INTERVAL == 0;
+    $rabbit->publish( 1, $rabbit_queue, encode_json( $msg ), {'exchange' => ''} );
+
+    $num_messages_sent += 1;
+}
+
+# Optionally wait until the data queue and/or an aggregate queue
+# have sufficiently-few messages in them
+sub check_queue_size {
+
+    my %args = (
+        url => "http://$rabbit_host:$rabbit_mgmt_port/api",
+    );
+
+    my $rabbit_management = Net::RabbitMQ::Management::API->new( %args );
+
+
+    while ( 1 ) {
+
+        my %queues;
+        $queues{$rabbit_queue} = $queue_size_limit if $queue_size_limit > 0;
+
+        if ( defined($check_aggregate_queue) and $aggregate_queue_size_limit > 0 ) {
+
+            $queues{$check_aggregate_queue} = $aggregate_queue_size_limit;
+        }
+
+        my $good;
+
+        foreach my $queue ( keys %queues ) {
+
+            # determine current rabbit queue size
+            my $queue_size;
+
+            eval {
+                
+                $queue_size = $rabbit_management->get_queue( name => $queue,
+                                                             vhost => '%2f' )->content()->{'messages'};
+            };
+
+            # detect error determining queue size
+            if ( $@ ) {
+                warn "Error getting queue info: $@";
+                $good = 0;
+                next;
+            }
+
+            my $max = $queues{$queue};
+
+            # we're over the max queue size, sleep awhile before trying again
+            if ( $queue_size && $queue_size > $max ) {
+                
+                warn "[$queue] Queue size is $queue_size > $max, sleeping...";
+                $good = 0;
+            }
+
+            $good = 1 if (! defined $good);
+        }
+
+        if ( ! $good ){
+            sleep( RETRY_TIMEOUT );
+            next;
+        }
+
+        # we're under the max queue size so we're safe to go ahead and publish our message
+        last;
+    }
 }
 
 sub usage {


### PR DESCRIPTION
This keeps the size of individual messages sent to RabbitMQ small even when the total number of simulated measurements is large compared to MESSAGE_SIZE.