### PR TITLE
Extrapolations as a series ISSUE=5887

### DIFF
--- a/conf/query_language.bnf
+++ b/conf/query_language.bnf
@@ -72,6 +72,8 @@ histogram ::= 'histogram' '(' field_word ',' number ')' action => remove_symbols
 extrapolate ::= 'extrapolate' '(' field_word ',' number ')' action => remove_symbols
                 |
                 'extrapolate' '(' field_word ',' date ')' action => remove_symbols
+                |
+                'extrapolate' '(' field_word ',' 'series' ')' action => remove_symbols
 		|
 		'extrapolate' '(' field ',' date ')' action => remove_symbols
                 |

--- a/conf/query_language.bnf
+++ b/conf/query_language.bnf
@@ -76,6 +76,8 @@ extrapolate ::= 'extrapolate' '(' field_word ',' number ')' action => remove_sym
 		'extrapolate' '(' field ',' date ')' action => remove_symbols
                 |
                 'extrapolate' '(' field ',' number ')' action => remove_symbols
+                |
+                'extrapolate' '(' field ',' 'series' ')' action => remove_symbols
 
 all ::= 'all' '(' field_word ')' action => remove_symbols
 

--- a/grnoc-tsds-services.spec
+++ b/grnoc-tsds-services.spec
@@ -65,6 +65,7 @@ Requires: perl-DBI
 Requires: perl-DBD-MySQL
 Requires: perl-GRNOC-Counter
 Requires: perl-Try-Tiny
+Requires: perl(List::Util)
 Requires: phantomjs
 
 

--- a/lib/GRNOC/TSDS/Parser.pm
+++ b/lib/GRNOC/TSDS/Parser.pm
@@ -3258,7 +3258,7 @@ sub _apply_extrapolate {
 
         # We want 20 "data points" if possible, subject to the constraint
         # that they need to have a spacing of at least 1 second:
-        my $npoints = max(1, min(int($end - $begin), 20));
+        my $npoints = max(1, min(int($end - $begin) + 1, 20));
         my @points;
 
         if ($npoints > 1) {

--- a/lib/GRNOC/TSDS/Parser.pm
+++ b/lib/GRNOC/TSDS/Parser.pm
@@ -14,6 +14,7 @@ use Clone qw(clone);
 use Math::Round qw( nlowmult );
 use Data::Dumper;
 use Sys::Hostname;
+use List::Util qw(min max);
 use POSIX;
 
 use GRNOC::Log;

--- a/lib/GRNOC/TSDS/Parser.pm
+++ b/lib/GRNOC/TSDS/Parser.pm
@@ -3252,8 +3252,10 @@ sub _apply_extrapolate {
     if ($extrapolate eq 'series'){
         my ($begin, $end);
         ($begin, $end) = @$time_range if defined($time_range);
-        $begin = (defined($end) ? $end-20 : 0) if !defined($begin);
-        $end = $begin + 1 if !defined($end);
+        if (!defined($begin) || !defined($end)){
+            $self->error('No time range specified for extrapolation series');
+            return;
+        }
         ($begin, $end) = ($end, $begin) if $end < $begin;
 
         # We want 20 "data points" if possible, subject to the constraint

--- a/lib/GRNOC/TSDS/Parser.pm
+++ b/lib/GRNOC/TSDS/Parser.pm
@@ -3263,15 +3263,18 @@ sub _apply_extrapolate {
         my $npoints = max(1, min(int($end - $begin) + 1, 20));
         my @points;
 
+        # calculate the times of our points
         if ($npoints > 1) {
             foreach my $i (0..($npoints-1)) {
-                my $tm = ($i * $end + ($npoints-1-$i) * $begin) / ($npoints-1);
-                push @points, [$tm, ($slope * $tm) + $intercept];
+                push @points, int( (($npoints-1-$i) * $begin + $i * $end) / ($npoints-1) );
             }
         }
         else {
-            push @points, [$end, ($slope * $end) + $intercept];
+            push @points, int($end);
         }
+
+        # get [time, extrapolated value] pairs
+        @points = map { [$_, ($slope * $_) + $intercept] } @points;
 
         $estimate = \@points;
     }

--- a/t/00init.t
+++ b/t/00init.t
@@ -77,6 +77,7 @@ my $tsds_install = GRNOC::TSDS::Install->new(
   config_file => $config_file );
 
 my $installed = $tsds_install->install();
+diag( 'GRNOC::TSDS::Install::install error: ' . $tsds_install->error) if defined($tsds_install->error);
 ok($installed, "Install Succeeded");
 
 # ISSUE=12363 verify sharding


### PR DESCRIPTION
Sometimes, it's useful to treat an extrapolation (currently based on line-fitting) as yet another timeseries (for simple integration into plots, say). This pull request adds support for that, as well as some tests of same.

(Ignore the ISSUE=6517 in some of the commit names — I got mixed up for a while.)